### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/yashnaiduu/Litelog/security/code-scanning/1](https://github.com/yashnaiduu/Litelog/security/code-scanning/1)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions in the workflow to the minimal scopes required. For this CI workflow, the steps only need to read the repository contents to build, vet, and test the Go code. Therefore, we can add `permissions: contents: read`. This can be defined at the workflow root (applies to all jobs) or at the job level. The best minimal change without altering behavior is to add a root-level `permissions` block right after the `name` field so that all jobs (currently only `build`) inherit `contents: read`. No other permissions (like `pull-requests`, `issues`, or `packages`) are required by the shown steps.

Concretely, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`) and before the `on:` block. No new imports or external definitions are needed since this is just a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to enhance security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->