### PR TITLE
format flag as referenced on #2

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -11,73 +11,128 @@ import (
 	"github.com/yashnaidu/litelog/storage"
 )
 
+
+import (
+       "encoding/csv"
+       "encoding/json"
+)
+
+var format string
+
 var queryCmd = &cobra.Command{
-	Use:   "query [sql]",
-	Short: "Run a SQL query against the logs database",
-	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		query := args[0]
-		if err := storage.InitDB(dbPath); err != nil {
-			log.Fatalf("Failed to initialize database: %v", err)
-		}
+       Use:   "query [sql]",
+       Short: "Run a SQL query against the logs database",
+       Args:  cobra.ExactArgs(1),
+       Run: func(cmd *cobra.Command, args []string) {
+	       query := args[0]
+	       if err := storage.InitDB(dbPath); err != nil {
+		       log.Fatalf("Failed to initialize database: %v", err)
+	       }
 
-		rows, err := storage.DB.Query(query)
-		if err != nil {
-			log.Fatalf("Query failed: %v", err)
-		}
-		defer rows.Close()
+	       rows, err := storage.DB.Query(query)
+	       if err != nil {
+		       log.Fatalf("Query failed: %v", err)
+	       }
+	       defer rows.Close()
 
-		cols, err := rows.Columns()
-		if err != nil {
-			log.Fatalf("Failed to get columns: %v", err)
-		}
+	       cols, err := rows.Columns()
+	       if err != nil {
+		       log.Fatalf("Failed to get columns: %v", err)
+	       }
 
-		// Setup tabwriter for aligned output
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, strings.Join(cols, "\t"))
+	       // Prepare to collect all rows
+	       var allRows [][]interface{}
+	       var allRowsMap []map[string]interface{}
+	       for rows.Next() {
+		       values := make([]interface{}, len(cols))
+		       valuePtrs := make([]interface{}, len(cols))
+		       for i := range cols {
+			       valuePtrs[i] = &values[i]
+		       }
+		       if err := rows.Scan(valuePtrs...); err != nil {
+			       log.Fatalf("Failed to scan row: %v", err)
+		       }
+		       rowCopy := make([]interface{}, len(cols))
+		       rowMap := make(map[string]interface{})
+		       for i, val := range values {
+			       var v interface{}
+			       if val == nil {
+				       v = nil
+			       } else {
+				       switch t := val.(type) {
+				       case []byte:
+					       v = string(t)
+				       default:
+					       v = t
+				       }
+			       }
+			       rowCopy[i] = v
+			       rowMap[cols[i]] = v
+		       }
+		       allRows = append(allRows, rowCopy)
+		       allRowsMap = append(allRowsMap, rowMap)
+	       }
+	       if err := rows.Err(); err != nil {
+		       log.Fatalf("Error iterating over rows: %v", err)
+	       }
 
-		// Print separator
-		separators := make([]string, len(cols))
-		for i, col := range cols {
-			separators[i] = strings.Repeat("-", len(col))
-		}
-		fmt.Fprintln(w, strings.Join(separators, "\t"))
-
-		values := make([]interface{}, len(cols))
-		valuePtrs := make([]interface{}, len(cols))
-		for i := range cols {
-			valuePtrs[i] = &values[i]
-		}
-
-		for rows.Next() {
-			if err := rows.Scan(valuePtrs...); err != nil {
-				log.Fatalf("Failed to scan row: %v", err)
-			}
-
-			var rowStrs []string
-			for _, val := range values {
-				if val == nil {
-					rowStrs = append(rowStrs, "NULL")
-				} else {
-					switch v := val.(type) {
-					case []byte:
-						rowStrs = append(rowStrs, string(v))
-					default:
-						rowStrs = append(rowStrs, fmt.Sprintf("%v", v))
-					}
-				}
-			}
-			fmt.Fprintln(w, strings.Join(rowStrs, "\t"))
-		}
-
-		if err := rows.Err(); err != nil {
-			log.Fatalf("Error iterating over rows: %v", err)
-		}
-		w.Flush()
-	},
+	       switch format {
+	       case "table":
+		       w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		       fmt.Fprintln(w, strings.Join(cols, "\t"))
+		       separators := make([]string, len(cols))
+		       for i, col := range cols {
+			       separators[i] = strings.Repeat("-", len(col))
+		       }
+		       fmt.Fprintln(w, strings.Join(separators, "\t"))
+		       for _, row := range allRows {
+			       var rowStrs []string
+			       for _, val := range row {
+				       if val == nil {
+					       rowStrs = append(rowStrs, "NULL")
+				       } else {
+					       rowStrs = append(rowStrs, fmt.Sprintf("%v", val))
+				       }
+			       }
+			       fmt.Fprintln(w, strings.Join(rowStrs, "\t"))
+		       }
+		       w.Flush()
+	       case "json":
+		       enc := json.NewEncoder(os.Stdout)
+		       enc.SetIndent("", "  ")
+		       if err := enc.Encode(allRowsMap); err != nil {
+			       log.Fatalf("Failed to encode JSON: %v", err)
+		       }
+	       case "csv":
+		       writer := csv.NewWriter(os.Stdout)
+		       if err := writer.Write(cols); err != nil {
+			       log.Fatalf("Failed to write CSV header: %v", err)
+		       }
+		       for _, row := range allRows {
+			       var record []string
+			       for _, val := range row {
+				       if val == nil {
+					       record = append(record, "NULL")
+				       } else {
+					       record = append(record, fmt.Sprintf("%v", val))
+				       }
+			       }
+			       if err := writer.Write(record); err != nil {
+				       log.Fatalf("Failed to write CSV row: %v", err)
+			       }
+		       }
+		       writer.Flush()
+		       if err := writer.Error(); err != nil {
+			       log.Fatalf("CSV writer error: %v", err)
+		       }
+	       default:
+		       log.Fatalf("Unknown format: %s. Supported formats: table, json, csv", format)
+	       }
+       },
 }
 
 func init() {
 	queryCmd.Flags().StringVar(&dbPath, "db", "litelog.db", "Path to SQLite database")
+	queryCmd.Flags().StringVar(&format, "format", "table", "Output format: table, json, or csv")
 	rootCmd.AddCommand(queryCmd)
 }


### PR DESCRIPTION
…n, and csv

## Summary

<!-- A concise description of what this PR does. -->

## Motivation

<!-- Why is this change needed? Link any related issues: Fixes #123 -->

## Changes

<!-- List the key changes made in this PR. -->

- 

## Testing

<!-- How was this tested? What commands did you run? -->

- [ ] `go test ./...` passes
- [ ] `go vet ./...` produces no output
- [ ] Manually tested locally

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on or be aware of. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Query command now supports multiple output formats: table (default), JSON, and CSV
* Added `--format` flag to specify desired output format
* JSON output displays results as an array of objects with column names as keys
* CSV output includes headers with "NULL" values for empty fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->